### PR TITLE
[ELY-816] Support for masked passwords in client XML config

### DIFF
--- a/elytron/ELY-816-masked-password.adoc
+++ b/elytron/ELY-816-masked-password.adoc
@@ -1,0 +1,74 @@
+= ELY-816 Support for masked passwords in client XML config
+:author:            Jan Kalina
+:email:             jkalina@redhat.com
+:toc:               left
+:icons:             font
+:keywords:          comma,separated,tags
+:idprefix:
+:idseparator:       -
+:issue-base-url:    https://issues.jboss.org/browse
+
+== Overview
+
+Elytron client should support masked passwords - passwords encrypted using predefined key, as it is supported in PicketBox.
+Masked passwords should be possible to use in place of any clear password written in Elytron Client XML configuration.
+
+For example, instead of:
+[source,xml]
+----
+<credentials>
+    <clear-password password="password"/>
+</credentials>
+----
+
+Following would be possible to use:
+
+[source,xml]
+----
+<credentials>
+    <masked-password iteration-count="12" salt="12345678" masked-password="j37uUs8kG9t2QSWjoxxtDg=="/>
+</credentials>
+----
+
+== Issue Metadata
+
+=== Issue
+
+* https://issues.jboss.org/browse/ELY-816[ELY-816]
+
+=== Related Issues
+
+* https://issues.jboss.org/browse/EAP7-1065[EAP7-1065]
+
+=== Dev Contacts
+
+* mailto:{jkalina@redhat.com}[Jan Kalina]
+
+=== QE Contacts
+
+* TBD
+
+=== Affected Projects or Components
+
+* WildFly Elytron
+
+=== Other Interested Projects
+
+== Requirements
+
+=== Hard Requirements
+
+* Everywhere in Elytron client configuration, where can be clear password used, should be possible to use masked password instead:
+** credential in authentication-configuration
+** key-store password
+** key-store reference (like in key-store-ssl-certificate)
+* Should be possible to migrate passwords in PicketBox-format into Elytron
+
+=== Nice-to-Have Requirements
+
+=== Non-Requirements
+
+== Test Plan
+
+Tests using Elytron client with clear-password should have copy, which will use masked password instead.
+


### PR DESCRIPTION
https://issues.jboss.org/browse/ELY-816
https://issues.jboss.org/browse/EAP7-1065

Elytron client should support masked passwords - passwords encrypted using predefined key, as it is supported in PicketBox, in any place in Elytron Client XML where clear passwords are currently used.