### PR TITLE
Add a Release Note section to the proposal template

### DIFF
--- a/design-doc-template.adoc
+++ b/design-doc-template.adoc
@@ -49,3 +49,13 @@ request so they are aware.
 ////
 Generally a feature should have documentation as part of the PR to wildfly master, or as a follow up PR if the feature is in wildfly-core. In some cases though the documentation belongs more in a component, or does not need any documentation. Indicate which of these will happen.
 ////
+== Release Note Content
+////
+Draft verbiage for up to a few sentences on the feature for inclusion in the
+Release Note blog article for the release that first includes this feature. 
+Example article: http://wildfly.org/news/2018/08/30/WildFly14-Final-Released/.
+This content will be edited, so there is no need to make it perfect or discuss
+what release it appears in.  "See Overview" is acceptable if the overview is
+suitable. For simple features best covered as an item in a bullet-point list 
+of features containing a few words on each, use "Bullet point: <The few words>" 
+////


### PR DESCRIPTION
Ease the WildFly release process by encouraging proposal authors to provide draft short text for an entry in the Release Note blog article.