### PR TITLE
[WFCORE-3542] / [WFCORE-3832] Add support for mod_crypt password and …

### DIFF
--- a/elytron/WFCORE-3542_WFCORE-3832-JDBC-realm-mod_crypt_hex.adoc
+++ b/elytron/WFCORE-3542_WFCORE-3832-JDBC-realm-mod_crypt_hex.adoc
@@ -1,0 +1,99 @@
+= JDBC Security Realm mod_crypt and HEX encoding support.
+:author:            Darran Lofthouse
+:email:             darran.lofthouse@redhat.com
+:toc:               left
+:icons:             font
+:idprefix:
+:idseparator:       -
+
+== Overview
+
+== Issue Metadata
+
+=== Issue
+
+* https://issues.jboss.org/browse/WFCORE-3542[WFCORE-3542]
+* https://issues.jboss.org/browse/WFCORE-3832[WFCORE-3832]
+
+=== Related Issues
+
+* https://issues.jboss.org/browse/WFLY-11923[WFLY-11923]
+
+=== Dev Contacts
+
+* mailto:{email}[{author}]
+
+=== QE Contacts
+
+=== Testing By
+
+[x] Engineering
+
+As an addition to an existing resource new scenarios can be added to an existing test case within the WildFly testsuite.
+
+[ ] QE
+
+=== Affected Projects or Components
+
+ * WildFly Elytron
+ * WildFly Core
+
+=== Other Interested Projects
+
+N/A
+
+== Requirements
+
+=== Hard Requirements
+
+==== https://issues.jboss.org/browse/WFCORE-3832[WFCORE-3832]
+
+The JDBC SecurityRealm support a variety of password mappers to load representations of a password from a database, many of these mappers load either hashed or digested representations of the password as well as any related salt from the database.  Presently the hashes, digests and, salts are all assumed to be Base64 encoded.
+
+This RFE is to add support for each of these to support hex encoding as an alternative encoding form.
+
+For each password mapper that supports the loading of a digested password representation a new optional attribute `hash-encoding` will be added to specify the encoding used, this will default to `base64` with an option to specify `hex` as an alternative encoding.
+
+For each password mapper that supports loading a salt a new optional attribute `salt-encoding` will be added to specify the encoding of the salt, this will default to `base64` with an option to specify `hex` as an alternative encoding.
+
+==== https://issues.jboss.org/browse/WFCORE-3542[WFCORE-3542]
+
+Many password types can be encoded using modular crypt allowing their hashed encoding, salt, and iteration count if applicable to be combined and represented in a single String, the JDBC SecurityRealm implementation already supports mod_crypt encoded password however this is not presently exposed on the subsystem, this RFE will add a new password mapper to the principal-query to support the loading of modular crypt encoded passwords.
+
+The new mapper will be called `modular-crypt-mapper`, the new mapper will contain a single: -
+
+ * `password-index` (Required) - To specify the column in the query result to obtain the password representation.
+ 
+ No further attributes are required on this mapper as the remaining information is obtained by decoding the encoded password representation. 
+ 
+=== Nice-to-Have Requirements
+
+=== Non-Requirements
+
+The configuration to specify the encoding will be contained within the individual password mapper definitions, there will be no high level option to change this globally.
+
+== Test Plan
+
+JDBC SecurityRealm testing was missing from the WildFly testsuite, this has now been added under https://issues.jboss.org/browse/WFLY-11931[WFLY-11932].
+
+For the development of this feature new tests will be added to the existing test case covering the following scenarios: -
+
+ * A mod_crypt JDBC realm will be defined.
+ * A second bcrypt realm will be defined but using HEX encoding for the hash and salt.
+ * Both of these scenarios will be added to the combined realm testing.
+
+Tests will be added to authenticate against each of the above realms. 
+
+Additionally within the WildFly Elytron subsystem tests will be added to parse and marshal a management model containing these new attributes and testing will be added to ensure transformers reject these new attributes from being sent to older hosts.
+
+== Community Documentation
+
+Detailed documentation of the JDBC SecurityRealm was missing from the community documentation, this has now beed added under https://issues.jboss.org/browse/WFLY-11820[WFLY-11820].
+
+For this RFE these changes will be added to the existing documentation: -
+
+ * The general password documentation will have a section added ilustrating encoding and decoding using modular crypt.
+ * The mod_crypt password mapper will be added to the list of mappers following the same pattern as for the existing mappers.
+ * The attribute descriptions for each mapper that supports hex encoding will be adjusted to reference the new attribute.
+ * The general disclaimer that states only Base64 encoding is supported will be adjusted.
+


### PR DESCRIPTION
…the hex encoding of passwords and salts to the JDBC SecurityRealm.

https://issues.jboss.org/browse/WFCORE-3542
https://issues.jboss.org/browse/WFCORE-3832
https://issues.jboss.org/browse/WFLY-11923