### PR TITLE
[ELY-1833] Add ability to KeyStoreCredentialStore to use Provider[] for passwords.

### DIFF
--- a/elytron/ELY-1833_KeyStoreCredentialStore_Provider[]_for_passwords.adoc
+++ b/elytron/ELY-1833_KeyStoreCredentialStore_Provider[]_for_passwords.adoc
@@ -1,0 +1,72 @@
+= Add ability to KeyStoreCredentialStore to use Provider[] for passwords.
+:author:            Ilia Vassilev
+:email:             ivassile@redhat.com
+:toc:               left
+:icons:             font
+:idprefix:
+:idseparator:       -
+
+== Overview
+
+The KeyStoreCredentialStore implementation does not use the Provider[] passed in during initialisation for PasswordFactory interaction. However it does use it for the underlying KeyStore. Any changes here will need to consider backwards compatibility as existing users may be used to this difference.
+
+Elytron Tool: Add new option to Credential Store command to utilize the new feature.
+Long option (no arguments): --providers-for-passwords
+Short option (no arguments): -w
+Description: Use the specified Provider(s) algorithm implementation for passwords.
+
+== Issue Metadata
+
+=== Issue
+
+* https://issues.jboss.org/browse/ELY-1833
+
+=== Related Issues
+
+=== Dev Contacts
+
+* mailto:{email}[{author}]
+* mailto:darran.lofthouse@redhat.com[Darran Lofthouse]
+* mailto:fjuma@redhat.com[Farah Juma]
+
+=== QE Contacts
+
+=== Testing By
+
+[X] Engineering
+
+[] QE
+
+=== Affected Projects or Components
+
+ * wildfly-elytron
+ * Elytron Tool
+ 
+=== Other Interested Projects
+
+== Requirements
+* The KeyStoreCredentialStore implementation does not use the Provider[] passed in during initialisation for PasswordFactory interaction. However it does use it for the underlying KeyStore. Modify KeyStoreCredentialStore implementation to use the Provider[] passed in during initialisation for PasswordFactory interaction.
+* Add new option to Credential Store command to utilize the new feature.
+Long option (no arguments): --providers-for-passwords
+Short option (no arguments): -w
+Description: Use the specified Provider(s) algorithm implementation for passwords.
+
+=== Hard Requirements
+
+=== Nice-to-Have Requirements
+
+=== Non-Requirements
+
+== Test Plan
+
+* The new option setUseInitializedProvidersForPasswords is set in the setUp() method in tests/base/src/test/java/org/wildfly/security/auth/client/XmlConfigurationTest.java
+* The new option setUseInitializedProvidersForPasswords is set in the setUp() method in tests/base/src/test/java/org/wildfly/security/credential/store/KeystorePasswordStoreTest.java
+
+== Community Documentation
+
+== Release Note Content
+
+New option added to Elytron Tool - Credential Store command:
+Long option (no arguments): --providers-for-passwords
+Short option (no arguments): -w
+Description: Use the specified Provider(s) algorithm implementation for passwords.


### PR DESCRIPTION
https://issues.jboss.org/browse/ELY-1833
https://issues.jboss.org/browse/EAP7-1360