### PR TITLE
[WFLY-15199] Add analysis for the removal of the legacy security subsystem.

### DIFF
--- a/security/WFLY-15199_Remove_Legacy_Security_Subsystem.adoc
+++ b/security/WFLY-15199_Remove_Legacy_Security_Subsystem.adoc
@@ -258,6 +258,9 @@ The following table identifies the tests in WildFly Core and WildFly affected by
 |org.jboss.as.security.service.SimpleSecurityServiceManagerMockTest
 |Removed
 
+|org.jboss.as.test.integration.security.jacc.context.PolicyContextTestCase
+|Ignored https://issues.redhat.com/browse/WFLY-15740[WFLY-15740]
+
 .Action Key
 |===
 |Action | Description

--- a/security/WFLY-15199_Remove_Legacy_Security_Subsystem.adoc
+++ b/security/WFLY-15199_Remove_Legacy_Security_Subsystem.adoc
@@ -255,6 +255,9 @@ The following table identifies the tests in WildFly Core and WildFly affected by
 |org.jboss.as.test.clustering.cluster.web.ReplicationForNegotiationAuthenticatorTestCase
 |Removed
 
+|org.jboss.as.security.service.SimpleSecurityServiceManagerMockTest
+|Removed
+
 .Action Key
 |===
 |Action | Description

--- a/security/WFLY-15199_Remove_Legacy_Security_Subsystem.adoc
+++ b/security/WFLY-15199_Remove_Legacy_Security_Subsystem.adoc
@@ -66,10 +66,14 @@ it's capabilities.
 The following subsystems will require additional configuration to default to WildFly Elytron
 security:
 
- * ejb2
+ * ejb3
  * iiop-openjdk
  * messaging-activemq
  * undertow
+ 
+For all subsystems that use a reference to a legacy security resource, these will remain usable in 
+`Stage.MODEL`  but will be flagged as deprecated. Where they are used in `Stage.RUNTIME` they 
+will result in an `OperationFailedException` as they can only be used on older hosts.
 
 === Nice-to-Have Requirements
 
@@ -260,6 +264,7 @@ The following table identifies the tests in WildFly Core and WildFly affected by
 
 |org.jboss.as.test.integration.security.jacc.context.PolicyContextTestCase
 |Ignored https://issues.redhat.com/browse/WFLY-15740[WFLY-15740]
+|===
 
 .Action Key
 |===

--- a/security/WFLY-15199_Remove_Legacy_Security_Subsystem.adoc
+++ b/security/WFLY-15199_Remove_Legacy_Security_Subsystem.adoc
@@ -1,0 +1,123 @@
+= [WFLY-15199] Remove legacy the security subystsem from the feature packs and convert to a skeleton,
+:author:            Darran Lofthouse
+:email:             darran.lofthouse@redhat.com
+:toc:               left
+:icons:             font
+:idprefix:
+:idseparator:       -
+
+== Overview
+
+During the development of WildFly 11 a new security solution using WildFly Elytron was integrated
+into WildFly in parallel with the legacy security solution based on PicketBox.  This enhancement 
+is to complete the activities to de-activate the legacy security subsystem and remove it from the
+default configurations and Galleon feature packs.
+
+== Issue Metadata
+
+=== Issue
+
+* https://issues.redhat.com/browse/WFLY-15199[WFLY-15199]
+
+=== Related Issues
+
+* 
+
+=== Dev Contacts
+
+* mailto:{email}[{author}]
+
+=== QE Contacts
+
+=== Testing By
+// Put an x in the relevant field to indicate if testing will be done by Engineering or QE. 
+// Discuss with QE during the Kickoff state to decide this
+* [ ] Engineering
+
+* [ ] QE
+
+=== Affected Projects or Components
+
+=== Other Interested Projects
+
+=== Relevant Installation Types
+// Remove the x next to the relevant field if the feature in question is not relevant
+// to that kind of WildFly installation
+* [x] Traditional standalone server (unzipped or provisioned by Galleon)
+
+* [x] Managed domain
+
+* [x] OpenShift s2i
+
+* [x] Bootable jar
+
+== Requirements
+
+=== Hard Requirements
+
+The `security` subsystem will be converted to a skeleton subsystem, this will mean that it can
+be used in domain mode to manage older servers but it can not be used for runtime configuration in
+WildFly 25 or later.
+
+All feature packs will be updated to remove the legacy security subsystem and any references to
+it's capabilities.
+
+The following subsystems will require additional configuration to default to WildFly Elytron
+security:
+
+ * ejb2
+ * iiop-openjdk
+ * messaging-activemq
+ * undertow
+
+=== Nice-to-Have Requirements
+
+=== Non-Requirements
+
+//== Implementation Plan
+////
+Delete if not needed. The intent is if you have a complex feature which can 
+not be delivered all in one go to suggest the strategy. If your feature falls 
+into this category, please mention the Release Coordinators on the pull 
+request so they are aware.
+////
+== Test Plan
+
+The following table identifies the tests in WildFly Core and WildFly affected by the removal.
+
+.Test Case Updates
+|===
+|Test Case |Action
+
+|
+|
+
+
+
+.Action Key
+|===
+|Action | Description
+
+|Ignored
+|Ignored to revisit.
+
+|Removed
+|Test case removed entirely.
+
+|Reduced
+|Removed vault specific testing from case.
+
+|Tweaked
+|Minor changes needed for vault removal.
+|===
+
+== Community Documentation
+
+After the removal is merged a full pass through the community documentation will be required to
+remove references to legacy security.
+
+== Release Note Content
+
+The legacy security subsystem has now been disabled for use at runtime and has been removed from
+the default configurations we ship and removed from the Galleon feature packs.  Users should 
+define their security resources within the `elytron` subsystem.

--- a/security/WFLY-15199_Remove_Legacy_Security_Subsystem.adoc
+++ b/security/WFLY-15199_Remove_Legacy_Security_Subsystem.adoc
@@ -17,11 +17,12 @@ default configurations and Galleon feature packs.
 
 === Issue
 
-* https://issues.redhat.com/browse/WFLY-15199[WFLY-15199]
+* https://issues.redhat.com/browse/WFLY-15199[WFLY-15199 - Remove legacy security configuration from all feature packs.]
+* https://issues.redhat.com/browse/WFLY-15301[WFLY-15301 - Convert the legacy security subsystem to a model only subsystem.]
 
 === Related Issues
 
-* 
+* https://issues.redhat.com/browse/EAP7-1094[EAP7-1094]
 
 === Dev Contacts
 

--- a/security/WFLY-15199_Remove_Legacy_Security_Subsystem.adoc
+++ b/security/WFLY-15199_Remove_Legacy_Security_Subsystem.adoc
@@ -137,18 +137,6 @@ The following table identifies the tests in WildFly Core and WildFly affected by
 |org.jboss.as.test.smoke.deployment.rar.tests.multiobjectpartialactivation.MultipleObjectPartialActivationTestCase
 |Ignored https://issues.redhat.com/browse/WFLY-15249[WFLY-15249]
 
-|org.jboss.as.test.integration.ws.authentication.EJBEndpointAuthenticationTestCase
-|Ignored https://issues.redhat.com/browse/WFLY-15253[WFLY-15253]
-
-|org.jboss.as.test.integration.ws.authentication.EJBEndpointNoClassLevelSecurityAnnotationAuthenticationTestCase
-|Ignored https://issues.redhat.com/browse/WFLY-15253[WFLY-15253]
-
-|org.jboss.as.test.integration.ws.authentication.EJBEndpointSecuredWSDLAccessTestCase
-|Ignored https://issues.redhat.com/browse/WFLY-15253[WFLY-15253]
-
-|org.jboss.as.test.integration.ws.authentication.PojoEndpointAuthenticationTestCase
-|Ignored https://issues.redhat.com/browse/WFLY-15253[WFLY-15253]
-
 |org.jboss.as.test.integration.security.loginmodules.CustomLoginModuleTestCase
 |Removed
 

--- a/security/WFLY-15199_Remove_Legacy_Security_Subsystem.adoc
+++ b/security/WFLY-15199_Remove_Legacy_Security_Subsystem.adoc
@@ -107,36 +107,6 @@ The following table identifies the tests in WildFly Core and WildFly affected by
 |org.jboss.as.test.integration.web.security.jaspi.WebSecurityJaspiWithFailingAuthModuleTestCase
 |Removed
 
-|org.jboss.as.test.smoke.deployment.rar.tests.earpackage.EarPackagedDeploymentTestCase
-|Ignored https://issues.redhat.com/browse/WFLY-15249[WFLY-15249]
-
-|org.jboss.as.test.smoke.deployment.rar.tests.multiactivation.MultipleActivationTestCase
-|Ignored https://issues.redhat.com/browse/WFLY-15249[WFLY-15249]
-
-|org.jboss.as.test.smoke.deployment.rar.tests.afterresourcecreation.AfterResourceCreationDeploymentTestCase
-|Ignored https://issues.redhat.com/browse/WFLY-15249[WFLY-15249]
-
-|org.jboss.as.test.smoke.deployment.rar.tests.configproperty.ConfigPropertyTestCase
-|Ignored https://issues.redhat.com/browse/WFLY-15249[WFLY-15249]
-
-|org.jboss.as.test.smoke.deployment.rar.tests.raconnection.RaTestConnectionTestCase
-|Ignored https://issues.redhat.com/browse/WFLY-15249[WFLY-15249]
-
-|org.jboss.as.test.integration.rar.RarDeploymentTestCase
-|Ignored https://issues.redhat.com/browse/WFLY-15249[WFLY-15249]
-
-|org.jboss.as.test.smoke.deployment.rar.tests.redeployment.ReDeploymentTestCase
-|Ignored https://issues.redhat.com/browse/WFLY-15249[WFLY-15249]
-
-|org.jboss.as.test.smoke.mgmt.resourceadapter.ResourceAdapterOperationsUnitTestCase
-|Ignored https://issues.redhat.com/browse/WFLY-15249[WFLY-15249]
-
-|org.jboss.as.test.smoke.deployment.rar.tests.multiobjectactivation.MultipleObjectActivationTestCase
-|Ignored https://issues.redhat.com/browse/WFLY-15249[WFLY-15249]
-
-|org.jboss.as.test.smoke.deployment.rar.tests.multiobjectpartialactivation.MultipleObjectPartialActivationTestCase
-|Ignored https://issues.redhat.com/browse/WFLY-15249[WFLY-15249]
-
 |org.jboss.as.test.integration.security.loginmodules.CustomLoginModuleTestCase
 |Removed
 
@@ -209,9 +179,6 @@ The following table identifies the tests in WildFly Core and WildFly affected by
 |org.jboss.as.test.integration.jca.security.IronJacamarActivationRaWithSecurityDomainTestCase
 |Removed
 
-|org.jboss.as.test.integration.jca.security.WildFlyActivationRaWithElytronAuthContextTestCase
-|Ignored https://issues.redhat.com/browse/WFLY-15249[WFLY-15249]
-
 |org.jboss.as.test.integration.management.api.security.SecurityDomainTestCase
 |Removed
 
@@ -223,33 +190,6 @@ The following table identifies the tests in WildFly Core and WildFly affected by
 
 |org.jboss.as.test.integration.security.cli.JsseTestCase
 |Removed
-
-|org.jboss.as.test.integration.jca.anno.NoRaAnnoTestCase
-|Ignored https://issues.redhat.com/browse/WFLY-15249[WFLY-15249]
-
-|org.jboss.as.test.integration.jca.anno.RaAnnoTestCase
-|Ignored https://issues.redhat.com/browse/WFLY-15249[WFLY-15249]
-
-|org.jboss.as.test.integration.jca.basic.BasicDeployment10TestCase
-|Ignored https://issues.redhat.com/browse/WFLY-15249[WFLY-15249]
-
-|org.jboss.as.test.integration.jca.basic.BasicDeployment15TestCase
-|Ignored https://issues.redhat.com/browse/WFLY-15249[WFLY-15249]
-
-|org.jboss.as.test.integration.jca.basic.BasicDeployment16TestCase
-|Ignored https://issues.redhat.com/browse/WFLY-15249[WFLY-15249]
-
-|org.jboss.as.test.integration.jca.basic.BasicDeployment17TestCase
-|Ignored https://issues.redhat.com/browse/WFLY-15249[WFLY-15249]
-
-|org.jboss.as.test.integration.jca.basic.BasicDoubleDeployment16TestCase
-|Ignored https://issues.redhat.com/browse/WFLY-15249[WFLY-15249]
-
-|org.jboss.as.test.integration.jca.basic.BasicDoubleDeploymentFail16_1TestCase
-|Ignored https://issues.redhat.com/browse/WFLY-15249[WFLY-15249]
-
-|org.jboss.as.test.integration.jca.basic.BasicDoubleDeploymentFail16_2TestCase
-|Ignored https://issues.redhat.com/browse/WFLY-15249[WFLY-15249]
 
 |org.jboss.as.test.integration.security.auditing.SecurityAuditingTestCase
 |Ignored https://issues.redhat.com/browse/WFLY-15263[WFLY-15263]
@@ -289,69 +229,6 @@ The following table identifies the tests in WildFly Core and WildFly affected by
 
 |org.wildfly.test.elytron.intermediate.X509SecurityDomainContextRealmTestCase
 |Removed
-
-|org.jboss.as.test.integration.jca.capacitypolicies.ResourceAdapterCapacityPoliciesTestCase
-|Ignored https://issues.redhat.com/browse/WFLY-15249[WFLY-15249]
-
-|org.jboss.as.test.integration.jca.ijdeployment.IronJacamarDeploymentTestCase
-|Ignored https://issues.redhat.com/browse/WFLY-15249[WFLY-15249]
-
-|org.jboss.as.test.integration.jca.ijdeployment.IronJacamarDoubleDeploymentTestCase
-|Ignored https://issues.redhat.com/browse/WFLY-15249[WFLY-15249]
-
-|org.jboss.as.test.integration.jca.metrics.RaCfgMetricUnitTestCase
-|Ignored https://issues.redhat.com/browse/WFLY-15249[WFLY-15249]
-
-|org.jboss.as.test.integration.jca.poolattributes.ResourceAdapterPoolAttributesTestCase
-|Ignored https://issues.redhat.com/browse/WFLY-15249[WFLY-15249]
-
-|org.jboss.as.test.integration.jca.statistics.ResourceAdapterStatisticsTestCase
-|Ignored https://issues.redhat.com/browse/WFLY-15249[WFLY-15249]
-
-|org.jboss.as.test.integration.jca.moduledeployment.BasicFlatTestCase
-|Ignored https://issues.redhat.com/browse/WFLY-15249[WFLY-15249]
-
-|org.jboss.as.test.integration.jca.moduledeployment.BasicJarTestCase
-|Ignored https://issues.redhat.com/browse/WFLY-15249[WFLY-15249]
-
-|org.jboss.as.test.integration.jca.moduledeployment.MultiActivationFlatTestCase
-|Ignored https://issues.redhat.com/browse/WFLY-15249[WFLY-15249]
-
-|org.jboss.as.test.integration.jca.moduledeployment.MultiActivationJarTestCase
-|Ignored https://issues.redhat.com/browse/WFLY-15249[WFLY-15249]
-
-|org.jboss.as.test.integration.jca.moduledeployment.MultiObjectActivationFlatTestCase
-|Ignored https://issues.redhat.com/browse/WFLY-15249[WFLY-15249]
-
-|org.jboss.as.test.integration.jca.moduledeployment.MultiObjectActivationJarTestCase
-|Ignored https://issues.redhat.com/browse/WFLY-15249[WFLY-15249]
-
-|org.jboss.as.test.integration.jca.moduledeployment.PartialObjectActivationFlatTestCase
-|Ignored https://issues.redhat.com/browse/WFLY-15249[WFLY-15249]
-
-|org.jboss.as.test.integration.jca.moduledeployment.PartialObjectActivationJarTestCase
-|Ignored https://issues.redhat.com/browse/WFLY-15249[WFLY-15249]
-
-|org.jboss.as.test.integration.jca.moduledeployment.PureFlatTestCase
-|Ignored https://issues.redhat.com/browse/WFLY-15249[WFLY-15249]
-
-|org.jboss.as.test.integration.jca.moduledeployment.PureJarTestCase
-|Ignored https://issues.redhat.com/browse/WFLY-15249[WFLY-15249]
-
-|org.jboss.as.test.integration.jca.moduledeployment.TwoModulesFlatTestCase
-|Ignored https://issues.redhat.com/browse/WFLY-15249[WFLY-15249]
-
-|org.jboss.as.test.integration.jca.moduledeployment.TwoModulesJarTestCase
-|Ignored https://issues.redhat.com/browse/WFLY-15249[WFLY-15249]
-
-|org.jboss.as.test.integration.jca.moduledeployment.TwoModulesOfDifferentTypeTestCase
-|Ignored https://issues.redhat.com/browse/WFLY-15249[WFLY-15249]
-
-|org.jboss.as.test.integration.jca.moduledeployment.TwoRaFlatTestCase
-|Ignored https://issues.redhat.com/browse/WFLY-15249[WFLY-15249]
-
-|org.jboss.as.test.integration.jca.moduledeployment.TwoRaJarTestCase
-|Ignored https://issues.redhat.com/browse/WFLY-15249[WFLY-15249]
 
 |org.wildfly.test.integration.vdx.standalone.MessagingTestCase.testWrongOrderOfElements
 |Ignored https://issues.redhat.com/browse/WFLY-15271[WFLY-15271]

--- a/security/WFLY-15199_Remove_Legacy_Security_Subsystem.adoc
+++ b/security/WFLY-15199_Remove_Legacy_Security_Subsystem.adoc
@@ -252,6 +252,9 @@ The following table identifies the tests in WildFly Core and WildFly affected by
 |org.jboss.as.testsuite.integration.secman.PBStaticMethodsTestCase
 |Removed
 
+|org.jboss.as.test.clustering.cluster.web.ReplicationForNegotiationAuthenticatorTestCase
+|Removed
+
 .Action Key
 |===
 |Action | Description

--- a/security/WFLY-15199_Remove_Legacy_Security_Subsystem.adoc
+++ b/security/WFLY-15199_Remove_Legacy_Security_Subsystem.adoc
@@ -89,9 +89,38 @@ The following table identifies the tests in WildFly Core and WildFly affected by
 |===
 |Test Case |Action
 
-|
-|
+|org.jboss.as.test.integration.web.security.WebSecuritySimpleRoleMappingSecurityManagerTestCase
+|Removed
 
+|org.jboss.as.test.integration.web.security.digest.WebSecurityDIGESTTestCase
+|Converted
+
+|org.jboss.as.test.integration.web.security.external.WebSecurityExternalAuthTestCase
+|Converted
+
+|org.jboss.as.test.integration.web.security.form.WebSecuritySimpleRoleMappingTestCase
+|Removed
+
+|org.jboss.as.test.integration.web.security.jaspi.WebSecurityJaspiTestCase
+|Removed
+
+|org.jboss.as.test.integration.web.security.jaspi.WebSecurityJaspiWithFailingAuthModuleTestCase
+|Removed
+
+|
+|Removed
+
+|
+|Removed
+
+|
+|Removed
+
+|
+|Removed
+
+|
+|Removed
 
 
 .Action Key
@@ -104,11 +133,8 @@ The following table identifies the tests in WildFly Core and WildFly affected by
 |Removed
 |Test case removed entirely.
 
-|Reduced
-|Removed vault specific testing from case.
-
-|Tweaked
-|Minor changes needed for vault removal.
+|Converted
+|Converted to use Elytron security exclusively.
 |===
 
 == Community Documentation

--- a/security/WFLY-15199_Remove_Legacy_Security_Subsystem.adoc
+++ b/security/WFLY-15199_Remove_Legacy_Security_Subsystem.adoc
@@ -359,30 +359,6 @@ The following table identifies the tests in WildFly Core and WildFly affected by
 |org.jboss.as.test.iiop.security.IIOPSecurityInvocationTestCase
 |Ignored https://issues.redhat.com/browse/WFLY-15271[WFLY-15271]
 
-|org.jboss.as.test.xts.wsba.participantcompletion.client.BAParticipantCompletionTestCase
-|Ignored https://issues.redhat.com/browse/WFLY-15275[WFLY-15275]
-
-|org.jboss.as.test.xts.wsat.client.ATTestCase
-|Ignored https://issues.redhat.com/browse/WFLY-15275[WFLY-15275]
-
-|org.jboss.as.test.xts.suspend.wsat.AtomicTransactionSuspendTestCase
-|Ignored https://issues.redhat.com/browse/WFLY-15275[WFLY-15275]
-
-|org.jboss.as.test.xts.annotation.client.TransactionalTestCase
-|Ignored https://issues.redhat.com/browse/WFLY-15275[WFLY-15275]
-
-|org.jboss.as.test.xts.wsba.coordinatorcompletion.client.BACoordinatorCompletionTestCase
-|Ignored https://issues.redhat.com/browse/WFLY-15275[WFLY-15275]
-
-|org.jboss.as.test.xts.annotation.client.CompensatableTestCase
-|Ignored https://issues.redhat.com/browse/WFLY-15275[WFLY-15275]
-
-|org.jboss.as.test.txbridge.fromjta.BridgeFromJTATestCase
-|Ignored https://issues.redhat.com/browse/WFLY-15275[WFLY-15275]
-
-|org.jboss.as.test.xts.suspend.wsba.BusinessActivitySuspendTestCase
-|Ignored https://issues.redhat.com/browse/WFLY-15275[WFLY-15275]
-
 |org.jboss.as.test.clustering.cluster.sso.ReplicatedSingleSignOnTestCase
 |Removed
 

--- a/security/WFLY-15199_Remove_Legacy_Security_Subsystem.adoc
+++ b/security/WFLY-15199_Remove_Legacy_Security_Subsystem.adoc
@@ -230,21 +230,185 @@ The following table identifies the tests in WildFly Core and WildFly affected by
 |org.jboss.as.test.integration.management.api.security.SecurityDomainDotNameTestCase
 |Removed
 
-|
+|org.jboss.as.test.integration.security.aselytron.SecurityDomainAsElytronSecurityRealmTestCase
 |Removed
 
-|
+|org.jboss.as.test.integration.security.cli.JsseTestCase
 |Removed
 
-|
+|org.jboss.as.test.integration.jca.anno.NoRaAnnoTestCase
+|Ignored https://issues.redhat.com/browse/WFLY-15249[WFLY-15249]
+
+|org.jboss.as.test.integration.jca.anno.RaAnnoTestCase
+|Ignored https://issues.redhat.com/browse/WFLY-15249[WFLY-15249]
+
+|org.jboss.as.test.integration.jca.basic.BasicDeployment10TestCase
+|Ignored https://issues.redhat.com/browse/WFLY-15249[WFLY-15249]
+
+|org.jboss.as.test.integration.jca.basic.BasicDeployment15TestCase
+|Ignored https://issues.redhat.com/browse/WFLY-15249[WFLY-15249]
+
+|org.jboss.as.test.integration.jca.basic.BasicDeployment16TestCase
+|Ignored https://issues.redhat.com/browse/WFLY-15249[WFLY-15249]
+
+|org.jboss.as.test.integration.jca.basic.BasicDeployment17TestCase
+|Ignored https://issues.redhat.com/browse/WFLY-15249[WFLY-15249]
+
+|org.jboss.as.test.integration.jca.basic.BasicDoubleDeployment16TestCase
+|Ignored https://issues.redhat.com/browse/WFLY-15249[WFLY-15249]
+
+|org.jboss.as.test.integration.jca.basic.BasicDoubleDeploymentFail16_1TestCase
+|Ignored https://issues.redhat.com/browse/WFLY-15249[WFLY-15249]
+
+|org.jboss.as.test.integration.jca.basic.BasicDoubleDeploymentFail16_2TestCase
+|Ignored https://issues.redhat.com/browse/WFLY-15249[WFLY-15249]
+
+|org.jboss.as.test.integration.security.auditing.SecurityAuditingTestCase
+|Ignored https://issues.redhat.com/browse/WFLY-15263[WFLY-15263]
+
+|org.jboss.as.test.integration.security.jaspi.EESecurityAuthMechanismMultiConstraintsTestCase
+|Ignored https://issues.redhat.com/browse/WFLY-15264[WFLY-15264]
+
+|org.jboss.as.test.integration.security.jaspi.EESecurityAuthMechanismTestCase
+|Ignored https://issues.redhat.com/browse/WFLY-15264[WFLY-15264]
+
+|org.jboss.as.test.integration.security.jaspi.JASPIHttpSchemeServerAuthModelTestCase
 |Removed
 
-|
+|org.jboss.as.test.integration.security.jaspi.JaspiFormAuthTestCase
 |Removed
 
-|
+|org.jboss.as.test.integration.security.xacml.EjbXACMLAuthorizationModuleTestCase
 |Removed
 
+|org.jboss.as.test.integration.security.xacml.JBossPDPInteroperabilityTestCase
+|Removed
+
+|org.jboss.as.test.integration.security.xacml.JBossPDPServletInitializationTestCase
+|Removed
+
+|org.jboss.as.test.integration.security.xacml.WebXACMLAuthorizationModuleTestCase
+|Removed
+
+|org.jboss.as.test.integration.security.loginmodules.databases.ExternalDatabaseLoginTestCase
+|Removed
+
+|org.jboss.as.test.integration.security.context.ReuseAuthenticatedSubjectTestCase
+|Removed
+
+|org.wildfly.test.elytron.intermediate.SecurityDomainContextRealmTestCase
+|Removed
+
+|org.wildfly.test.elytron.intermediate.X509SecurityDomainContextRealmTestCase
+|Removed
+
+|org.jboss.as.test.integration.jca.capacitypolicies.ResourceAdapterCapacityPoliciesTestCase
+|Ignored https://issues.redhat.com/browse/WFLY-15249[WFLY-15249]
+
+|org.jboss.as.test.integration.jca.ijdeployment.IronJacamarDeploymentTestCase
+|Ignored https://issues.redhat.com/browse/WFLY-15249[WFLY-15249]
+
+|org.jboss.as.test.integration.jca.ijdeployment.IronJacamarDoubleDeploymentTestCase
+|Ignored https://issues.redhat.com/browse/WFLY-15249[WFLY-15249]
+
+|org.jboss.as.test.integration.jca.metrics.RaCfgMetricUnitTestCase
+|Ignored https://issues.redhat.com/browse/WFLY-15249[WFLY-15249]
+
+|org.jboss.as.test.integration.jca.poolattributes.ResourceAdapterPoolAttributesTestCase
+|Ignored https://issues.redhat.com/browse/WFLY-15249[WFLY-15249]
+
+|org.jboss.as.test.integration.jca.statistics.ResourceAdapterStatisticsTestCase
+|Ignored https://issues.redhat.com/browse/WFLY-15249[WFLY-15249]
+
+|org.jboss.as.test.integration.jca.moduledeployment.BasicFlatTestCase
+|Ignored https://issues.redhat.com/browse/WFLY-15249[WFLY-15249]
+
+|org.jboss.as.test.integration.jca.moduledeployment.BasicJarTestCase
+|Ignored https://issues.redhat.com/browse/WFLY-15249[WFLY-15249]
+
+|org.jboss.as.test.integration.jca.moduledeployment.MultiActivationFlatTestCase
+|Ignored https://issues.redhat.com/browse/WFLY-15249[WFLY-15249]
+
+|org.jboss.as.test.integration.jca.moduledeployment.MultiActivationJarTestCase
+|Ignored https://issues.redhat.com/browse/WFLY-15249[WFLY-15249]
+
+|org.jboss.as.test.integration.jca.moduledeployment.MultiObjectActivationFlatTestCase
+|Ignored https://issues.redhat.com/browse/WFLY-15249[WFLY-15249]
+
+|org.jboss.as.test.integration.jca.moduledeployment.MultiObjectActivationJarTestCase
+|Ignored https://issues.redhat.com/browse/WFLY-15249[WFLY-15249]
+
+|org.jboss.as.test.integration.jca.moduledeployment.PartialObjectActivationFlatTestCase
+|Ignored https://issues.redhat.com/browse/WFLY-15249[WFLY-15249]
+
+|org.jboss.as.test.integration.jca.moduledeployment.PartialObjectActivationJarTestCase
+|Ignored https://issues.redhat.com/browse/WFLY-15249[WFLY-15249]
+
+|org.jboss.as.test.integration.jca.moduledeployment.PureFlatTestCase
+|Ignored https://issues.redhat.com/browse/WFLY-15249[WFLY-15249]
+
+|org.jboss.as.test.integration.jca.moduledeployment.PureJarTestCase
+|Ignored https://issues.redhat.com/browse/WFLY-15249[WFLY-15249]
+
+|org.jboss.as.test.integration.jca.moduledeployment.TwoModulesFlatTestCase
+|Ignored https://issues.redhat.com/browse/WFLY-15249[WFLY-15249]
+
+|org.jboss.as.test.integration.jca.moduledeployment.TwoModulesJarTestCase
+|Ignored https://issues.redhat.com/browse/WFLY-15249[WFLY-15249]
+
+|org.jboss.as.test.integration.jca.moduledeployment.TwoModulesOfDifferentTypeTestCase
+|Ignored https://issues.redhat.com/browse/WFLY-15249[WFLY-15249]
+
+|org.jboss.as.test.integration.jca.moduledeployment.TwoRaFlatTestCase
+|Ignored https://issues.redhat.com/browse/WFLY-15249[WFLY-15249]
+
+|org.jboss.as.test.integration.jca.moduledeployment.TwoRaJarTestCase
+|Ignored https://issues.redhat.com/browse/WFLY-15249[WFLY-15249]
+
+|org.wildfly.test.integration.vdx.standalone.MessagingTestCase.testWrongOrderOfElements
+|Ignored https://issues.redhat.com/browse/WFLY-15271[WFLY-15271]
+
+|org.jboss.as.test.iiop.security.IIOPSecurityInvocationTestCase
+|Ignored https://issues.redhat.com/browse/WFLY-15271[WFLY-15271]
+
+|org.jboss.as.test.xts.wsba.participantcompletion.client.BAParticipantCompletionTestCase
+|Ignored https://issues.redhat.com/browse/WFLY-15275[WFLY-15275]
+
+|org.jboss.as.test.xts.wsat.client.ATTestCase
+|Ignored https://issues.redhat.com/browse/WFLY-15275[WFLY-15275]
+
+|org.jboss.as.test.xts.suspend.wsat.AtomicTransactionSuspendTestCase
+|Ignored https://issues.redhat.com/browse/WFLY-15275[WFLY-15275]
+
+|org.jboss.as.test.xts.annotation.client.TransactionalTestCase
+|Ignored https://issues.redhat.com/browse/WFLY-15275[WFLY-15275]
+
+|org.jboss.as.test.xts.wsba.coordinatorcompletion.client.BACoordinatorCompletionTestCase
+|Ignored https://issues.redhat.com/browse/WFLY-15275[WFLY-15275]
+
+|org.jboss.as.test.xts.annotation.client.CompensatableTestCase
+|Ignored https://issues.redhat.com/browse/WFLY-15275[WFLY-15275]
+
+|org.jboss.as.test.txbridge.fromjta.BridgeFromJTATestCase
+|Ignored https://issues.redhat.com/browse/WFLY-15275[WFLY-15275]
+
+|org.jboss.as.test.xts.suspend.wsba.BusinessActivitySuspendTestCase
+|Ignored https://issues.redhat.com/browse/WFLY-15275[WFLY-15275]
+
+|org.jboss.as.test.clustering.cluster.sso.ReplicatedSingleSignOnTestCase
+|Removed
+
+|org.jboss.as.test.clustering.cluster.sso.remote.RemoteSingleSignOnTestCase
+|Removed
+
+|org.wildfly.test.manual.management.MPScriptTestCase.testFailure()
+|Removed
+
+|org.jboss.as.test.manualmode.security.SecuredDataSourceTestCase
+|Removed
+
+|org.jboss.as.testsuite.integration.secman.PBStaticMethodsTestCase
+|Removed
 
 .Action Key
 |===

--- a/security/WFLY-15199_Remove_Legacy_Security_Subsystem.adoc
+++ b/security/WFLY-15199_Remove_Legacy_Security_Subsystem.adoc
@@ -107,6 +107,129 @@ The following table identifies the tests in WildFly Core and WildFly affected by
 |org.jboss.as.test.integration.web.security.jaspi.WebSecurityJaspiWithFailingAuthModuleTestCase
 |Removed
 
+|org.jboss.as.test.smoke.deployment.rar.tests.earpackage.EarPackagedDeploymentTestCase
+|Ignored https://issues.redhat.com/browse/WFLY-15249[WFLY-15249]
+
+|org.jboss.as.test.smoke.deployment.rar.tests.multiactivation.MultipleActivationTestCase
+|Ignored https://issues.redhat.com/browse/WFLY-15249[WFLY-15249]
+
+|org.jboss.as.test.smoke.deployment.rar.tests.afterresourcecreation.AfterResourceCreationDeploymentTestCase
+|Ignored https://issues.redhat.com/browse/WFLY-15249[WFLY-15249]
+
+|org.jboss.as.test.smoke.deployment.rar.tests.configproperty.ConfigPropertyTestCase
+|Ignored https://issues.redhat.com/browse/WFLY-15249[WFLY-15249]
+
+|org.jboss.as.test.smoke.deployment.rar.tests.raconnection.RaTestConnectionTestCase
+|Ignored https://issues.redhat.com/browse/WFLY-15249[WFLY-15249]
+
+|org.jboss.as.test.integration.rar.RarDeploymentTestCase
+|Ignored https://issues.redhat.com/browse/WFLY-15249[WFLY-15249]
+
+|org.jboss.as.test.smoke.deployment.rar.tests.redeployment.ReDeploymentTestCase
+|Ignored https://issues.redhat.com/browse/WFLY-15249[WFLY-15249]
+
+|org.jboss.as.test.smoke.mgmt.resourceadapter.ResourceAdapterOperationsUnitTestCase
+|Ignored https://issues.redhat.com/browse/WFLY-15249[WFLY-15249]
+
+|org.jboss.as.test.smoke.deployment.rar.tests.multiobjectactivation.MultipleObjectActivationTestCase
+|Ignored https://issues.redhat.com/browse/WFLY-15249[WFLY-15249]
+
+|org.jboss.as.test.smoke.deployment.rar.tests.multiobjectpartialactivation.MultipleObjectPartialActivationTestCase
+|Ignored https://issues.redhat.com/browse/WFLY-15249[WFLY-15249]
+
+|org.jboss.as.test.integration.ws.authentication.EJBEndpointAuthenticationTestCase
+|Ignored https://issues.redhat.com/browse/WFLY-15253[WFLY-15253]
+
+|org.jboss.as.test.integration.ws.authentication.EJBEndpointNoClassLevelSecurityAnnotationAuthenticationTestCase
+|Ignored https://issues.redhat.com/browse/WFLY-15253[WFLY-15253]
+
+|org.jboss.as.test.integration.ws.authentication.EJBEndpointSecuredWSDLAccessTestCase
+|Ignored https://issues.redhat.com/browse/WFLY-15253[WFLY-15253]
+
+|org.jboss.as.test.integration.ws.authentication.PojoEndpointAuthenticationTestCase
+|Ignored https://issues.redhat.com/browse/WFLY-15253[WFLY-15253]
+
+|org.jboss.as.test.integration.security.loginmodules.CustomLoginModuleTestCase
+|Removed
+
+|org.jboss.as.test.integration.security.loginmodules.DatabaseLoginModuleTestCase
+|Removed
+
+|org.jboss.as.test.integration.security.loginmodules.IdentityLoginModuleTestCase
+|Removed
+
+|org.jboss.as.test.integration.security.loginmodules.LdapExtLikeAdvancedLdapLMTestCase
+|Removed
+
+|org.jboss.as.test.integration.security.loginmodules.LdapExtLoginModuleTestCase
+|Removed
+
+|org.jboss.as.test.integration.security.loginmodules.LdapExtPasswordCachingTestCase
+|Removed
+
+|org.jboss.as.test.integration.security.loginmodules.LdapLoginModuleTestCase
+|Removed
+
+|org.jboss.as.test.integration.security.loginmodules.MultipleCustomLoginModulesTest
+|Removed
+
+|org.jboss.as.test.integration.security.loginmodules.RunAsLoginModuleTestCase
+|Removed
+
+|org.jboss.as.test.integration.security.loginmodules.UsersRolesLoginModuleTestCase
+|Removed
+
+|org.jboss.as.test.integration.security.jaas.JAASIdentityCachingTestCase
+|Removed
+
+|org.jboss.as.test.integration.security.loginmodules.negotiation.SPNEGOLoginModuleTestCase
+|Removed
+
+|org.jboss.as.test.integration.security.loginmodules.negotiation.AdvancedLdapLoginModuleTestCase
+|Removed
+
+|org.jboss.as.test.integration.security.auditing.CustomAuditProviderModuleTest
+|Removed
+
+|org.jboss.as.test.integration.web.security.runas.WebSecurityRunAsTestCase
+|Ignored https://issues.redhat.com/browse/WFLY-15261[WFLY-15261]
+
+|org.jboss.as.test.integration.web.security.servlet.methods.DenyUncoveredHttpMethodsTestCase
+|Ignored https://issues.redhat.com/browse/WFLY-15261[WFLY-15261]
+
+|org.jboss.as.test.integration.jca.security.WildFlyActivationRaWithSecurityDomainTestCase
+|Removed
+
+|org.jboss.as.test.integration.jca.security.DsWithSecurityDomainTestCase
+|Removed
+
+|org.jboss.as.test.integration.jca.security.WildFlyActivationRaWithMixedSecurityTestCase
+|Removed
+
+|org.jboss.as.test.integration.jca.security.DsWithMixedSecurityTestCase
+|Removed
+
+|org.jboss.as.test.integration.jca.security.workmanager.WildFlyActivationRaWithWMSecurityDomainWorkManagerTestCase
+|Removed
+
+|org.jboss.as.test.integration.ejb.security.callerprincipal.GetCallerPrincipalWithNoDefaultSecurityDomainTestCase
+|Ignored https://issues.redhat.com/browse/WFLY-15262[WFLY-15262]
+
+|org.jboss.as.test.integration.ejb.security.RunAsPrincipalCustomDomainTestCase
+|Removed
+
+|org.jboss.as.test.integration.jca.security.IronJacamarActivationRaWithSecurityDomainTestCase
+|Removed
+
+|org.jboss.as.test.integration.jca.security.WildFlyActivationRaWithElytronAuthContextTestCase
+|Ignored https://issues.redhat.com/browse/WFLY-15249[WFLY-15249]
+
+|org.jboss.as.test.integration.management.api.security.SecurityDomainTestCase
+|Removed
+
+|org.jboss.as.test.integration.management.api.security.SecurityDomainDotNameTestCase
+|Removed
+
 |
 |Removed
 


### PR DESCRIPTION
This is the initial analysis for the removal of the legacy security subsystem.

https://issues.redhat.com/browse/WFLY-15199