### PR TITLE
[WFLY-15286] Migrate RESTEasy from 4.x to 5.x

### DIFF
--- a/jaxrs/WFLY-15286-resteasy-5-upgrade.adoc
+++ b/jaxrs/WFLY-15286-resteasy-5-upgrade.adoc
@@ -1,0 +1,135 @@
+= Upgrade RESTEasy from 4.x to 5.x
+:author:            James R. Perkins
+:email:             jperkins@redhat.com
+:toc:               left
+:icons:             font
+:idprefix:
+:idseparator:       -
+
+== Overview
+
+RESTEasy 5.x will be Jakarta REST 2.1 (Jakarta EE 8) compliant. While RESTEasy 6.x will be Jakarta REST 3.0 (Jakarta EE 9)
+compliant. The MicroProfile REST Client, MicroProfile REST Config Sources and Spring were moved out of the project and
+into new projects. This was due to the project dependencies not being Jakarta EE 9.1 compliant.
+
+There will should be minimal differences between 4.7.x and 5.x except GAV changes for these 3 projects. One new module will
+be introduced for the `org.jboss.resteasy.microprofile:microprofile-config`.
+
+* https://github.com/resteasy/resteasy-microprofile
+* https://github.com/resteasy/resteasy-spring
+
+|===
+|Old GA |New GA
+
+|`org.jboss.resteasy:resteasy-client-microprofile`
+|`org.jboss.resteasy.microprofile:microprofile-rest-client`
+
+|`org.jboss.resteasy:resteasy-client-microprofile-base`
+|`org.jboss.resteasy.microprofile:microprofile-rest-client-bas`
+
+|`org.jboss.resteasy:resteasy-spring`
+|`org.jboss.resteasy.spring:resteasy-spring`
+|===
+
+== Issue Metadata
+
+=== Issue
+
+* https://issues.redhat.com/browse/WFLY-15286[WFLY-15286]
+
+=== Related Issues
+
+* https://issues.redhat.com/browse/EAP7-1832[EAP7-1832]
+* https://issues.redhat.com/browse/WFLY-15287[WFLY-15287]
+* https://issues.redhat.com/browse/WFLY-15436[WFLY-15436]
+* https://issues.redhat.com/browse/WFLY-15705[WFLY-15705]
+* https://issues.redhat.com/browse/RESTEASY-3007[RESTEASY-3007]
+* https://issues.redhat.com/browse/RESTEASY-2975[RESTEASY-2975]
+* https://issues.redhat.com/browse/RESTEASY-2976[RESTEASY-2976]
+
+=== Dev Contacts
+
+* mailto:{email}[{author}]
+
+=== QE Contacts
+
+TBD
+
+=== Testing By
+
+* [ ] Engineering
+
+* [ ] QE
+
+=== Affected Projects or Components
+
+* WildFly, and sub-projects
+* Quickstarts
+
+=== Other Interested Projects
+
+=== Relevant Installation Types
+* [x] Traditional standalone server (unzipped or provisioned by Galleon)
+
+* [x] Managed domain
+
+* [x] OpenShift s2i
+
+* [x] Bootable jar
+
+== Requirements
+
+=== Hard Requirements
+
+* Replace the RESTEasy MicroProfile client in WildFly
+* Do not change any runtime module names.
+* Add the `org.jboss.resteasy.microprofile:microprofile-config` module.
+* As part of the 5.x upgrade, WildFly Preview will be upgraded to RESTEasy 6.x for native Jakarta EE 9.1 support of
+  Jakarta RESTful Web Services.
+* RESTEasy Spring will be removed due to the fact there is currently no version of Spring which targets Jakarta EE 9+
+** Note that the `JaxrsSpringProcessor` *must* remain in the subsystem. If a user explicitly installs Spring and
+   RESTEasy Spring this process will be required.
+* Quickstarts, especially for Spring, will require some changes. This needs to be done in conjunction with this change.
+** The quickstarts that use Spring should change to include RESTEasy Spring in the deployment.
+
+=== Nice-to-Have Requirements
+
+=== Non-Requirements
+
+== Test Plan
+
+The current test suite and Jakarta EE TCK should be sufficient for testing. The MicroProfile TCK is run as part of the
+resteasy-microprofile project.
+
+== Community Documentation
+
+Community documentation will need to be updated to show the changes for the Maven group id's and artifact id's.
+
+== Release Note Content
+
+RESTEasy has migrated the Eclipse MicroProfile support out of RESTEasy core into a
+https://github.com/resteasy/resteasy-microprofile[new project]. Functionally nothing has changed. The only requirement
+is a change to the Maven group id and artifact id required to use the MicroProfile REST Client and MicroProfile Config
+sources.
+
+RESTEasy Spring has been removed from WildFly. This was done as there is no current release of Spring which supports
+the `jakarta` namespace change.
+
+|===
+|Old GA |New GA
+
+|`org.jboss.resteasy:resteasy-client-microprofile`
+|`org.jboss.resteasy.microprofile:microprofile-rest-client`
+
+|`org.jboss.resteasy:resteasy-client-microprofile-base`
+|`org.jboss.resteasy.microprofile:microprofile-rest-client-bas`
+
+|`org.jboss.resteasy:resteasy-spring`
+|`org.jboss.resteasy.spring:resteasy-spring`
+|===
+
+The following features have been added to 5.x:
+
+* https://issues.redhat.com/browse/RESTEASY-2880[RESTEASY-2880]: Threshold before writing to disk should be configurable
+* https://issues.redhat.com/browse/RESTEASY-3021[RESTEASY-3021]: Create a way to propagate the RESTEasy context for new threads
+


### PR DESCRIPTION
https://issues.redhat.com/browse/WFLY-15286