### PR TITLE
Add admin client requirements to the process

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,6 +30,8 @@ transaction.log
 *.swp
 /.gitk-tmp.*
 atlassian-ide-plugin.xml
+# VSCode Files
+.vscode
 # temp files
 *~
 # maven versions plugin

--- a/FEATURE_PROCESS.adoc
+++ b/FEATURE_PROCESS.adoc
@@ -75,7 +75,7 @@ All hard requirements in analysis covered
 | *Admin Clients*
 (HAL / JBoss CLI)
 
-| Management model changes must be compatible with the lowe level model
+| Management model changes must be compatible with the lower level model
 manipulation capabilities of the admin clients.
 
 Breakage of high level client functionality is undesirable but accepted.

--- a/FEATURE_PROCESS.adoc
+++ b/FEATURE_PROCESS.adoc
@@ -70,6 +70,32 @@ All hard requirements in analysis covered
 | Encouraged |Encouraged |Encouraged |Required
 //-------
 
+//-------
+
+| *Admin Clients*
+(HAL / JBoss CLI)
+
+| Management model changes must be compatible with the lowe level model
+manipulation capabilities of the admin clients.
+
+Breakage of high level client functionality is undesirable but accepted.
+
+| Experimental plus:
+
+Existing functionality in the admin clients must not be broken by the new
+addition.  Higher level client integration is not required.
+
+| Preview plus:
+
+Existing higher level views and commands in the admin clients must be
+compatible with the new functionality.
+
+New higher level views and command in the admin clients are not mandatory
+unless required for the feature to be considered "complete".
+
+| Same as Community
+
+//-------
 
 //-------
 | *Component Validation*

--- a/design-doc-template.adoc
+++ b/design-doc-template.adoc
@@ -103,6 +103,16 @@ into this category, please mention the Release Coordinators on the pull
 request so they are aware.
 ////
 
+== Admin Clients
+
+////
+Identify the level of compatibility this feature will have with the existing
+admin clients (JBoss CLI and the Admin Console / HAL).
+
+Identify any follow up work that will be required in the clients and link issues
+created to track this work.
+////
+
 == Security Considerations
 
 ////

--- a/design-doc-template.adoc
+++ b/design-doc-template.adoc
@@ -105,13 +105,7 @@ request so they are aware.
 
 == Admin Clients
 
-////
-Identify the level of compatibility this feature will have with the existing
-admin clients (JBoss CLI and the Admin Console / HAL).
-
-Identify any follow up work that will be required in the clients and link issues
-created to track this work.
-////
+__<Identify the level of compatibility this feature will have with the existing admin clients (JBoss CLI and the Admin Console / HAL). Identify any follow up work that will be required in the clients and link issues created to track this work.>__
 
 == Security Considerations
 


### PR DESCRIPTION
The updates I am proposing here relate to how in general the admin clients should be considered when new features are added to the application server.

The admin clients are maintained by smaller teams within the overall WildFly team, for this reason it is not going to scale if every feature requires complete admin client integration at every stability level so the general premise behind this proposal is that features can be added at Experimental or Preview level with a reduced set of admin client requirements, the admin clients can then continue to evolve to add these features and then the underlying feature can be promoted to Community / Default.

Note: This is not so much about features being added directly to the admin clients at the stability levels as in that case the admin client developer is already in control of compatibility etc...
