### PR TITLE
Fix design doc template bad copy paste.

### DIFF
--- a/design-doc-template.adoc
+++ b/design-doc-template.adoc
@@ -153,8 +153,7 @@ Depending on the stability level, the test plan required may vary. see below:
 == Community Documentation
 
 __<Describe how this feature will be documented or illustrated. Generally a feature should have documentation as part of the PR to wildfly main, or as a follow up PR if the feature is in wildfly-core. In some cases though the feature will bring additional content (such as quickstarts, guides, etc.). Indicate which of these will happen>__
- +** Default - This stability level is reserved and requires approval by a professional Quality Engineer with subject matter expertise.
- 
+
 == Release Note Content
 
 __<Draft verbiage for up to a few sentences on the feature for inclusion in the Release Note blog article for the release that first includes this feature.__


### PR DESCRIPTION
There an error paste from above section introduced in @jmesnil 's PR: https://github.com/wildfly/wildfly-proposals/commit/6e61aa84d66ad1f6fdf87628780420211b97d21b#diff-1e46fd5b24b8df67bec2629d044ee017dc0e62542e582563b1abf9a29db7dfe6R112

This fixes that.