### PR TITLE
Add \n between metadata table and TOC syntax start

### DIFF
--- a/design-doc-template.adoc
+++ b/design-doc-template.adoc
@@ -30,6 +30,7 @@ promotes:
 # of this feature to a higher stability level
 promoted-by:
 ---
+
 = <INSERT TITLE HERE>
 :author:            Your Name
 :email:             your.email@redhat.com


### PR DESCRIPTION
Just new line to separate metadata and TOC. Some editors are tad more strict or too strict and will swallow first paragraph of TOC.