### PR TITLE
Fix rendering in MicroProfile Platform 7.1 proposal

### DIFF
--- a/microprofile/WFLY-20684_microprofile_platform_7.1.adoc
+++ b/microprofile/WFLY-20684_microprofile_platform_7.1.adoc
@@ -235,6 +235,7 @@ bring additional content (such as quickstarts, guides, etc.) Indicate which of t
 ////
 
 Tracked in https://issues.redhat.com/browse/WFLY-20956[WFLY-20956]:
+
 * There is a list of version of the individual specifications here https://github.com/wildfly/wildfly/blob/main/docs/src/main/asciidoc/Getting_Started_Guide.adoc?plain=1#L119-L129 This table will be updated to list the new versions
 * The subsystem configuration documentation for https://github.com/wildfly/wildfly/blob/main/docs/src/main/asciidoc/_admin-guide/subsystem-configuration/MicroProfile_OpenAPI.adoc[MicroProfile OpenAPI] has some links which include the current version of the specification. These will be updated.
 


### PR DESCRIPTION
This proposal https://docs.wildfly.org/wildfly-proposals/microprofile/WFLY-20684_microprofile_platform_7.1.html is linked from the release notes https://www.wildfly.org/news/2025/10/16/WildFly-38-is-released/ so let it render properly.

Lists require an empty preceeding line.