### PR TITLE
[WFCORE-7565] Add proposal for ACME external account binding

### DIFF
--- a/security/WFCORE-7565-acme-external-account-binding.adoc
+++ b/security/WFCORE-7565-acme-external-account-binding.adoc
@@ -9,7 +9,8 @@ feature-team:
  sme:
   - skyllarr
  outside-perspective:
-
+  - jasondlee
+ 
 promotes:
 promoted-by:
 ---

--- a/security/WFCORE-7565-acme-external-account-binding.adoc
+++ b/security/WFCORE-7565-acme-external-account-binding.adoc
@@ -92,7 +92,7 @@ This proposal does not require HAL specific UI changes for the feature to be com
 
 === Future Work
 
-Future work may include promoting the feature from `preview` to `community` stability after broader compatibility and interoperability testing.
+Future work may include promoting the feature from `preview` to `community` or `default` stability after broader compatibility and interoperability testing.
 
 Future work may also include additional documentation examples for certificate authorities that require EAB.
 

--- a/security/WFCORE-7565-acme-external-account-binding.adoc
+++ b/security/WFCORE-7565-acme-external-account-binding.adoc
@@ -66,15 +66,15 @@ The Elytron `certificate-authority-account` resource must allow users to configu
 The management model must expose two optional attributes:
 
 * `external-account-binding-key-identifier`
-* `external-account-binding-hmac-key`
+* `credential-reference` containing the EAB HMAC key
 
 Both attributes must remain optional so existing ACME account configurations continue to work without modification.
 
-If one EAB attribute is configured, the other EAB attribute must also be configured. WildFly must reject incomplete EAB configurations with a clear error message.
+If the EAB key identifier is configured, an EAB HMAC key credential reference must also be configured. WildFly must reject incomplete EAB configurations with a clear error message.
 
 When both EAB attributes are configured, WildFly must pass the values to the Elytron ACME account builder during ACME account creation.
 
-The HMAC key must be treated as sensitive credential-like configuration and must not be exposed in logs or detailed error messages.
+The HMAC key must be configured using Elytron's credential-reference mechanism and must not be exposed in logs or detailed error messages.
 
 The new management attributes must be marked with `preview` stability metadata.
 
@@ -124,7 +124,7 @@ The implementation will update the Elytron subsystem in WildFly Core.
 
 `CertificateAuthorityAccountDefinition` will be updated to add the new EAB management attributes.
 
-Validation logic will ensure that the EAB key identifier and HMAC key must be configured together.
+Validation logic will ensure that the EAB key identifier and HMAC key credential reference must be configured together.
 
 The runtime service creation path will resolve the new attributes and pass them to `AcmeAccountService`.
 
@@ -142,7 +142,7 @@ An example CLI configuration may look like:
     alias=account-key,
     contact-urls=["mailto:admin@example.com"],
     external-account-binding-key-identifier="example-kid",
-    external-account-binding-hmac-key="example-hmac-key"
+    external-account-binding-hmac-key-credential-reference={clear-text="example-hmac-key"}
 )
 ----
 
@@ -191,7 +191,7 @@ Lower level tests for construction of the ACME `externalAccountBinding` payload 
 
 WildFly Elytron documentation should be updated to describe the new EAB attributes on the `certificate-authority-account` resource.
 
-The documentation should explain that the key identifier and HMAC key are supplied by the certificate authority and that both values are required when EAB is used.
+The documentation should explain that the key identifier is supplied by the certificate authority and that the HMAC key should be configured using an Elytron credential reference.
 
 The documentation should include a short CLI example showing a `certificate-authority-account` configured with EAB attributes.
 

--- a/security/WFCORE-7565-acme-external-account-binding.adoc
+++ b/security/WFCORE-7565-acme-external-account-binding.adoc
@@ -150,6 +150,21 @@ An example CLI configuration may look like:
 )
 ----
 
+The equivalent XML configuration may look like:
+
+[source,xml,options="nowrap"]
+----
+<certificate-authority-account name="my-ca" ...>
+    <account-key key-store="..." alias="...">
+        <credential-reference clear-text="..."/>
+    </account-key>
+    <external-account-binding>
+        <key-identifier>example-kid</key-identifier>
+        <credential-reference store="my-cs" alias="eab-hmac-key"/>
+    </external-account-binding>
+</certificate-authority-account>
+----
+
 == Admin Clients
 
 The new EAB attributes will be exposed through the standard WildFly management model.

--- a/security/WFCORE-7565-acme-external-account-binding.adoc
+++ b/security/WFCORE-7565-acme-external-account-binding.adoc
@@ -26,13 +26,13 @@ promoted-by:
 
 WildFly Elytron provides ACME client support for creating and managing ACME accounts used in automated certificate issuance. Some certificate authorities require ACME External Account Binding, commonly referred to as EAB, when creating a new ACME account. EAB allows the certificate authority to associate the ACME account with an existing non-ACME account, such as a customer account in the CA platform.
 
-This proposal adds support for configuring EAB values on the Elytron `certificate-authority-account` resource in WildFly Core. Users will be able to configure the CA supplied key identifier and HMAC key as part of the ACME account configuration. During ACME account creation, WildFly will pass these values into the Elytron ACME client so the ACME `newAccount` request can include the required `externalAccountBinding` data.
+This proposal adds support for configuring EAB values on the Elytron `certificate-authority-account` resource in WildFly Core. Users will be able to configure an optional `external-account-binding` configuration containing a key identifier and credential reference for the HMAC key. During ACME account creation, WildFly will pass these values into the Elytron ACME client so the ACME `newAccount` request can include the required `externalAccountBinding` data.
 
 The feature is proposed at `preview` stability. Existing ACME account configurations will continue to work without modification, and EAB will only be used when explicitly configured.
 
 === User Stories
 
-As a WildFly administrator using a certificate authority that requires External Account Binding, I want to configure the EAB key identifier and HMAC key in the Elytron `certificate-authority-account` resource, so that WildFly can create the ACME account directly.
+As a WildFly administrator using a certificate authority that requires External Account Binding,I want to configure the EAB key identifier and HMAC key credential reference in the Elytron `certificate-authority-account` resource, so that WildFly can create the ACME account directly.
 
 As a WildFly administrator using a certificate authority that does not require EAB, I want my existing ACME account configuration to continue working without any new required configuration.
 
@@ -201,4 +201,4 @@ The documentation should include a short CLI example showing a `certificate-auth
 
 == Release Note Content
 
-WildFly now supports configuring ACME External Account Binding on Elytron certificate authority accounts at `preview` stability. This allows WildFly to create ACME accounts with certificate authorities that require a key identifier and HMAC key during account registration.
+WildFly now supports configuring ACME External Account Binding on Elytron certificate authority accounts at `preview` stability. This allows WildFly to create ACME accounts with certificate authorities that require a key identifier and HMAC key credential reference during account registration.

--- a/security/WFCORE-7565-acme-external-account-binding.adoc
+++ b/security/WFCORE-7565-acme-external-account-binding.adoc
@@ -63,14 +63,16 @@ No additional projects are expected to be directly affected by this feature.
 
 The Elytron `certificate-authority-account` resource must allow users to configure the values required for ACME External Account Binding.
 
-The management model must expose two optional attributes:
+The management model must expose an optional `external-account-binding` configuration containing:
 
-* `external-account-binding-key-identifier`
-* `credential-reference` containing the EAB HMAC key
+* `key-identifier`
+* `credential-reference`
 
-Both attributes must remain optional so existing ACME account configurations continue to work without modification.
+The `credential-reference` contains the EAB HMAC key.
 
-If the EAB key identifier is configured, an EAB HMAC key credential reference must also be configured. WildFly must reject incomplete EAB configurations with a clear error message.
+The `external-account-binding` configuration must remain optional so existing ACME account configurations continue to work without modification.
+
+If `external-account-binding` is configured, both `key-identifier` and `credential-reference` must be configured. WildFly must reject incomplete EAB configurations with a clear error message.
 
 When both EAB attributes are configured, WildFly must pass the values to the Elytron ACME account builder during ACME account creation.
 
@@ -122,9 +124,9 @@ This feature improves interoperability with ACME certificate authorities that re
 
 The implementation will update the Elytron subsystem in WildFly Core.
 
-`CertificateAuthorityAccountDefinition` will be updated to add the new EAB management attributes.
+`CertificateAuthorityAccountDefinition` will be updated to add an optional `external-account-binding` configuration containing `key-identifier` and `credential-reference`.
 
-Validation logic will ensure that the EAB key identifier and HMAC key credential reference must be configured together.
+Validation logic will ensure that when `external-account-binding` is present, both `key-identifier` and `credential-reference` are configured.
 
 The runtime service creation path will resolve the new attributes and pass them to `AcmeAccountService`.
 
@@ -141,8 +143,10 @@ An example CLI configuration may look like:
     key-store=account-key-store,
     alias=account-key,
     contact-urls=["mailto:admin@example.com"],
-    external-account-binding-key-identifier="example-kid",
-    external-account-binding-hmac-key-credential-reference={clear-text="example-hmac-key"}
+    external-account-binding={
+        key-identifier="example-kid",
+        credential-reference={clear-text="example-hmac-key"}
+    }
 )
 ----
 
@@ -177,11 +181,11 @@ This feature is proposed at `preview` stability, so the test plan will focus on 
 
 Automated tests should verify that a `certificate-authority-account` can still be added without EAB attributes configured.
 
-Automated tests should verify that a `certificate-authority-account` can be added with both EAB attributes configured.
+Automated tests should verify that a `certificate-authority-account` can be added with `external-account-binding` configured.
 
-Automated tests should verify that configuring only `external-account-binding-key-identifier` fails.
+Automated tests should verify that configuring `external-account-binding` with only `key-identifier` fails.
 
-Automated tests should verify that configuring only `external-account-binding-hmac-key` fails.
+Automated tests should verify that configuring `external-account-binding` with only `credential-reference` fails.
 
 Automated tests should verify that the configured EAB values are passed into the ACME account creation path.
 
@@ -189,7 +193,7 @@ Lower level tests for construction of the ACME `externalAccountBinding` payload 
 
 == Community Documentation
 
-WildFly Elytron documentation should be updated to describe the new EAB attributes on the `certificate-authority-account` resource.
+WildFly Elytron documentation should be updated to describe the new `external-account-binding` configuration on the `certificate-authority-account` resource.
 
 The documentation should explain that the key identifier is supplied by the certificate authority and that the HMAC key should be configured using an Elytron credential reference.
 

--- a/security/WFCORE-7565-acme-external-account-binding.adoc
+++ b/security/WFCORE-7565-acme-external-account-binding.adoc
@@ -1,0 +1,200 @@
+---
+categories:
+- security
+- management
+stability-level: preview
+issue: https://redhat.atlassian.net/browse/WFCORE-7565
+feature-team:
+ developer: Zhang-Charlie
+ sme:
+  - skyllarr
+ outside-perspective:
+
+promotes:
+promoted-by:
+---
+
+= Add External Account Binding Support to the Elytron ACME Client
+:author:            Charlie Zhang
+:email:             charliezhangbusiness@gmail.com
+:toc:               left
+:icons:             font
+:idprefix:
+:idseparator:       -
+
+== Overview
+
+WildFly Elytron provides ACME client support for creating and managing ACME accounts used in automated certificate issuance. Some certificate authorities require ACME External Account Binding, commonly referred to as EAB, when creating a new ACME account. EAB allows the certificate authority to associate the ACME account with an existing non-ACME account, such as a customer account in the CA platform.
+
+This proposal adds support for configuring EAB values on the Elytron `certificate-authority-account` resource in WildFly Core. Users will be able to configure the CA supplied key identifier and HMAC key as part of the ACME account configuration. During ACME account creation, WildFly will pass these values into the Elytron ACME client so the ACME `newAccount` request can include the required `externalAccountBinding` data.
+
+The feature is proposed at `preview` stability. Existing ACME account configurations will continue to work without modification, and EAB will only be used when explicitly configured.
+
+=== User Stories
+
+As a WildFly administrator using a certificate authority that requires External Account Binding, I want to configure the EAB key identifier and HMAC key in the Elytron `certificate-authority-account` resource, so that WildFly can create the ACME account directly.
+
+As a WildFly administrator using a certificate authority that does not require EAB, I want my existing ACME account configuration to continue working without any new required configuration.
+
+== Issue Metadata
+
+=== Related Issues
+
+* https://issues.redhat.com/browse/WFCORE-7565[WFCORE-7565]
+* https://issues.redhat.com/browse/ELY-2951[ELY-2951]
+
+=== Affected Projects or Components
+
+* https://github.com/wildfly/wildfly-core[wildfly-core]
+* https://github.com/wildfly-security/wildfly-elytron[wildfly-elytron]
+
+=== Other Interested Projects
+
+No additional projects are expected to be directly affected by this feature.
+
+=== Relevant Installation Types
+
+* Traditional standalone server (unzipped or provisioned by Galleon)
+* Managed domain
+* OpenShift Source-to-Image (S2I)
+* Bootable jar
+
+== Requirements
+
+The Elytron `certificate-authority-account` resource must allow users to configure the values required for ACME External Account Binding.
+
+The management model must expose two optional attributes:
+
+* `external-account-binding-key-identifier`
+* `external-account-binding-hmac-key`
+
+Both attributes must remain optional so existing ACME account configurations continue to work without modification.
+
+If one EAB attribute is configured, the other EAB attribute must also be configured. WildFly must reject incomplete EAB configurations with a clear error message.
+
+When both EAB attributes are configured, WildFly must pass the values to the Elytron ACME account builder during ACME account creation.
+
+The HMAC key must be treated as sensitive credential-like configuration and must not be exposed in logs or detailed error messages.
+
+The new management attributes must be marked with `preview` stability metadata.
+
+=== Non-Requirements
+
+This proposal does not implement a new ACME client.
+
+This proposal does not change the ACME account creation flow for users who do not configure EAB.
+
+This proposal does not add CA specific account registration workflows beyond standard External Account Binding support.
+
+This proposal does not introduce a new certificate authority resource type.
+
+This proposal does not require HAL specific UI changes for the feature to be complete.
+
+=== Future Work
+
+Future work may include promoting the feature from `preview` to `community` stability after broader compatibility and interoperability testing.
+
+Future work may also include additional documentation examples for certificate authorities that require EAB.
+
+== Backwards Compatibility
+
+This feature is backward compatible. The new attributes are optional and existing `certificate-authority-account` resources will continue to function without modification.
+
+=== Default Configuration
+
+The default WildFly configuration is unchanged.
+
+No EAB key identifier or HMAC key is configured by default.
+
+=== Importing Existing Configuration
+
+Existing configurations that do not contain the new EAB attributes will continue to work without migration changes.
+
+=== Deployments
+
+This feature does not change deployment behavior.
+
+=== Interoperability
+
+This feature improves interoperability with ACME certificate authorities that require External Account Binding during account creation.
+
+== Implementation Plan
+
+The implementation will update the Elytron subsystem in WildFly Core.
+
+`CertificateAuthorityAccountDefinition` will be updated to add the new EAB management attributes.
+
+Validation logic will ensure that the EAB key identifier and HMAC key must be configured together.
+
+The runtime service creation path will resolve the new attributes and pass them to `AcmeAccountService`.
+
+`AcmeAccountService` will pass the values to the Elytron ACME account builder when both attributes are configured.
+
+The lower level ACME request handling is expected to be provided by the corresponding WildFly Elytron implementation for ELY-2951.
+
+An example CLI configuration may look like:
+
+[source,options="nowrap"]
+----
+/subsystem=elytron/certificate-authority-account=my-ca-account:add(
+    certificate-authority=my-ca,
+    key-store=account-key-store,
+    alias=account-key,
+    contact-urls=["mailto:admin@example.com"],
+    external-account-binding-key-identifier="example-kid",
+    external-account-binding-hmac-key="example-hmac-key"
+)
+----
+
+== Admin Clients
+
+The new EAB attributes will be exposed through the standard WildFly management model.
+
+Users will be able to configure the attributes through the CLI and other management clients that interact with the management model.
+
+No new high level CLI command is required.
+
+Existing admin client functionality must remain compatible with the addition of the new attributes.
+
+HAL specific integration is not required for the initial `preview` implementation.
+
+== Security Considerations
+
+The EAB HMAC key is credential-like data supplied by the certificate authority and should be treated as sensitive configuration.
+
+The value must not be written to logs or exposed in detailed error messages.
+
+For management RBAC purposes, the HMAC key attribute should use the `CREDENTIAL` sensitivity classification.
+
+Access to configure or read this value should follow Elytron security-sensitive management behavior and existing RBAC restrictions for security configuration.
+
+Incorrect disclosure of the HMAC key could allow unauthorized attempts to bind an ACME account to an external CA account, depending on the CA policy.
+
+[[test_plan]]
+== Test Plan
+
+This feature is proposed at `preview` stability, so the test plan will focus on automated management model tests and integration coverage for the path between WildFly Core and the Elytron ACME account builder.
+
+Automated tests should verify that a `certificate-authority-account` can still be added without EAB attributes configured.
+
+Automated tests should verify that a `certificate-authority-account` can be added with both EAB attributes configured.
+
+Automated tests should verify that configuring only `external-account-binding-key-identifier` fails.
+
+Automated tests should verify that configuring only `external-account-binding-hmac-key` fails.
+
+Automated tests should verify that the configured EAB values are passed into the ACME account creation path.
+
+Lower level tests for construction of the ACME `externalAccountBinding` payload are expected to be covered in the WildFly Elytron implementation.
+
+== Community Documentation
+
+WildFly Elytron documentation should be updated to describe the new EAB attributes on the `certificate-authority-account` resource.
+
+The documentation should explain that the key identifier and HMAC key are supplied by the certificate authority and that both values are required when EAB is used.
+
+The documentation should include a short CLI example showing a `certificate-authority-account` configured with EAB attributes.
+
+== Release Note Content
+
+WildFly now supports configuring ACME External Account Binding on Elytron certificate authority accounts at `preview` stability. This allows WildFly to create ACME accounts with certificate authorities that require a key identifier and HMAC key during account registration.


### PR DESCRIPTION
https://redhat.atlassian.net/browse/WFCORE-7565

Add support for configuring External Account Binding (EAB) in Elytron ACME client. This feature allows users to specify EAB key identifier and HMAC key for ACME account creation, enhancing compatibility with certificate authorities requiring EAB.