### PR TITLE
[ELY-3051] Add native PEM KeyStore support for Kubernetes TLS

### DIFF
--- a/elytron/ELY-3051-native-pem-keystore-kubernetes-tls.adoc
+++ b/elytron/ELY-3051-native-pem-keystore-kubernetes-tls.adoc
@@ -1,0 +1,232 @@
+---
+# Add any category for this proposal as a YAML list, e.g.
+# - core
+# - management
+# If missing, add it to _data/wildfly-categories and use its id
+categories:
+  - cloud
+  - security
+  - core
+  - elytron
+# Specify the stability level of the feature.
+# Values can be one of: experimental, preview, community, or default
+stability-level: preview
+# Specify the Feature Development tracker issue for the feature.
+# This must be an issue tracked in https://github.com/orgs/wildfly/projects/7/views/1.
+# To create a Feature Development tracker issue, go to https://github.com/wildfly/wildfly-proposals/issues/new/choose
+# and select 'Feature Development'
+issue: https://github.com/wildfly/wildfly-proposals/issues/<FEATURE_PLANNING_ISSUE_NUMBER>
+# Provide the GitHub ids of the feature team members, organized by role.
+# Provide a single id for the 'assignee' role. Use a YAML list for the 'sme' and
+# 'outside-perspective' roles, even if there is only one person in a role.
+feature-team:
+ developer: Zhang-Charlie
+ sme:
+  - # need to add
+ outside-perspective:
+  - # need to add
+# If this issue tracks the promotion of a previously completed feature to a higher stability level, provide the URL of
+# the original https://github.com/wildfly/wildfly-proposals/issues issue that was used to track the implementation of
+# that feature.
+promotes:
+# During initial development of a feature, this field should be left blank. If after the feature is completed and its
+# stability level is promoted via a later issue, the developer promoting the issue should return to this document ("this"
+# being the original analysis document for the feature). The field should be updated to point to the
+# https://github.com/wildfly/wildfly-proposals/issues issue that promotes it.
+# For example,
+#              | Implementation Issue (A) | Promotion Issue (B)
+# promotes:    |                          | https://github.com/.../A
+# promoted-by: | https://github.com/.../B |
+promoted-by:
+---
+
+= Native PEM KeyStore support for Kubernetes TLS secrets
+:author:            Charlie Zhang
+:email:             charliezhangbusiness@gmail.com
+:toc:               left
+:icons:             font
+:idprefix:
+:idseparator:       -
+
+== Overview
+
+WildFly is commonly deployed in Kubernetes environments where TLS credentials are provided as Kubernetes TLS secrets. These secrets are mounted into containers as PEM-encoded files, typically `tls.crt` for the certificate chain and `tls.key` for the private key.
+
+Elytron currently integrates with Java keystore-based TLS configuration, but it does not provide a native PEM keystore type for directly loading Kubernetes-style TLS secret files. Users therefore need to convert PEM files into JKS or PKCS12 before WildFly can use them. This adds extra deployment logic, makes certificate rotation harder to automate, and introduces another possible failure point during server startup.
+
+This feature adds native PEM KeyStore support to Elytron using Java's standard `KeyStoreSpi` mechanism. The goal is to allow WildFly to consume PEM certificate and key material directly while reusing the existing Elytron TLS pipeline, including `KeyStore`, `KeyManager`, `TrustManager`, and `SSLContext`.
+
+=== User Stories
+
+As a WildFly user deploying to Kubernetes, I want to mount a Kubernetes TLS secret and configure WildFly to use the mounted `tls.crt` and `tls.key` files directly, so that I do not need an init container or startup script to convert them into PKCS12.
+
+As an administrator managing certificate rotation, I want WildFly TLS configuration to align with the Kubernetes secret format, so that the deployment is simpler and easier to automate.
+
+As a WildFly maintainer, I want PEM support to integrate through Java's standard keystore SPI mechanism, so that the existing Elytron TLS infrastructure can continue to be used without introducing a separate TLS pipeline.
+
+== Issue Metadata
+
+=== Related Issues
+
+* Feature Planning: https://github.com/wildfly/wildfly-proposals/issues/835
+* ELY: https://redhat.atlassian.net/browse/ELY-3051
+* Feature Pack: https://github.com/wildfly-security-incubator/kubernetes-tls-secrets-feature-pack
+
+=== Affected Projects or Components
+
+* `wildfly-security/wildfly-elytron`: main implementation of the PEM parser, PEM `KeyStoreSpi`, provider registration, and unit tests.
+* `wildfly-security-incubator/kubernetes-tls-secrets-feature-pack`: feature-pack integration, subsystem configuration, documentation, and validation for Kubernetes TLS secret usage.
+* `wildfly/wildfly`: possible integration testing, documentation, and end-to-end validation with a full WildFly server.
+
+=== Other Interested Projects
+
+This feature may be relevant to WildFly Kubernetes and OpenShift deployment documentation because it reduces the need for external PEM to keystore conversion when TLS secrets are mounted into containers.
+
+=== Relevant Installation Types
+
+* Traditional standalone server (unzipped or provisioned by Galleon)
+* OpenShift Source-to-Image (S2I)
+* Bootable jar
+
+This feature is especially relevant to container and Kubernetes deployments where TLS material is commonly provided through mounted secret files.
+
+== Requirements
+
+The feature must provide a native PEM keystore type for Elytron.
+
+The implementation must support loading X.509 certificate material from PEM files.
+
+The implementation must support loading private key material from PEM files, with PKCS#8 as the primary supported private key encoding.
+
+The implementation must support the Kubernetes TLS secret layout where the certificate chain and private key are provided as separate files, usually `tls.crt` and `tls.key`.
+
+The implementation must expose the PEM keystore type through Java's standard keystore provider mechanism, so that `KeyStore.getInstance("PEM")` can be used after the Elytron provider is registered.
+
+The PEM keystore should be read-only, since Kubernetes manages the lifecycle of the mounted secret files.
+
+The implementation must avoid logging or exposing private key material in error messages.
+
+The implementation should provide clear errors for malformed PEM files, missing files, unreadable files, unsupported key material, and mismatched certificate/private key pairs.
+
+The Kubernetes TLS secrets feature pack should provide a dedicated subsystem that allows users to configure the PEM certificate path and private key path in a way that is compatible with existing Elytron TLS configuration patterns.
+
+=== Changed requirements
+
+Not applicable. This proposal introduces a new feature at preview stability and does not promote or change the requirements of an existing feature.
+
+=== Non-Requirements
+
+This feature does not require Kubernetes Operator changes.
+
+This feature does not require adding new external dependencies.
+
+This feature does not require support for non-PEM keystore formats.
+
+Encrypted PEM support is not required for the initial implementation.
+
+File watching or automatic reload of changed Kubernetes secrets is not required for the initial implementation.
+
+Certificate rotation handling beyond normal reload or restart behaviour is not required for the initial implementation.
+
+=== Future Work
+
+Future work may include encrypted PEM support, automatic reload or file watching support for rotated Kubernetes secrets, broader private key format support if required, and promotion from preview to community stability after the feature has received sufficient usage, testing, documentation, and maintainer review.
+
+== Backwards Compatibility
+
+This feature is additive and should not change the behaviour of existing JKS, PKCS12, or PKCS11 keystore configurations.
+
+=== Default Configuration
+
+The proposed work should not change the default value of any existing configuration attribute.
+
+The proposed work should not change the configuration generated by existing Galleon layers.
+
+=== Importing Existing Configuration
+
+Existing server configurations should continue to work without migration.
+
+This feature should not require any changes to the WildFly server migration tool.
+
+=== Deployments
+
+This feature should not change deployment behaviour in an incompatible way.
+
+Applications and deployments that do not use the new PEM keystore type should be unaffected.
+
+=== Interoperability
+
+The feature should interoperate with the existing Elytron TLS pipeline, including key managers, trust managers, and SSL contexts.
+
+The feature should also work naturally in Kubernetes-style environments where TLS material is mounted as separate PEM files.
+
+== Implementation Plan
+
+The Elytron implementation will add a PEM parser and a read-only `KeyStoreSpi` implementation for PEM material. The provider will register a PEM keystore type. The initial implementation will focus on Kubernetes-style identity material consisting of a certificate chain and private key.
+
+The expected flow is:
+
+[source]
+----
+tls.crt + tls.key -> PEM parser -> PemKeyStoreSpi -> KeyStore(PEM) -> Elytron -> SSLContext
+----
+
+The Kubernetes TLS secrets feature pack will provide a dedicated subsystem with configuration that allows users to configure both the certificate path and private key path for PEM keystores.
+
+A possible CLI shape is:
+
+[source]
+----
+/subsystem=cloud-security/key-store=k8s-tls:add(
+    type=PEM,
+    path=/var/run/secrets/tls/tls.crt,
+    key-path=/var/run/secrets/tls/tls.key
+)
+----
+
+The exact management model shape should be confirmed with the feature team before merge, since naming and model details may change during implementation.
+
+== Admin Clients
+
+Existing low-level CLI resource manipulation should continue to work.
+
+If a new subsystem management attribute such as `key-path` is added, it should include correct metadata and should not break existing CLI behaviour.
+
+Higher-level admin client integration is not required for the initial preview feature unless the feature team decides it is necessary for completeness.
+
+== Security Considerations
+
+This feature handles private key material and therefore must avoid exposing private key contents through logs, error messages, management responses, or debug output.
+
+The PEM keystore should be read-only, matching the Kubernetes secret lifecycle model.
+
+If new management attributes are introduced for paths to key material, the feature team should confirm whether additional security-sensitive metadata is required. The current proposal expects file paths rather than storing private key contents directly in the management model.
+
+Any attribute that stores credential material directly would need to be treated as security-sensitive. This proposal does not require storing private key contents in the management model.
+
+[[test_plan]]
+== Test Plan
+
+This feature is proposed at preview stability.
+
+Testing will include unit tests, integration tests, and manual Kubernetes-style validation.
+
+Unit tests should cover valid PEM certificates, valid private keys, certificate chains, malformed PEM blocks, empty files, missing files, unreadable files, unsupported key formats, mismatched certificate and private key pairs, deterministic alias behaviour, and read-only KeyStore operations.
+
+Provider tests should verify that the PEM keystore type can be obtained using `KeyStore.getInstance("PEM")` once the Elytron provider is registered.
+
+Integration tests should verify that a PEM-loaded KeyStore can be used with Elytron key manager, trust manager, and SSL context configuration.
+
+Manual validation should use a Kubernetes-style file layout with mounted `tls.crt` and `tls.key` files. The validation should include at least one self-signed example and one CA-issued certificate chain example where practical.
+
+== Community Documentation
+
+Documentation should explain how to configure WildFly to use a Kubernetes TLS secret mounted as PEM files.
+
+The documentation should include a worked CLI example, describe the expected `tls.crt` and `tls.key` file layout, and explain that the PEM keystore is intended to avoid external conversion to JKS or PKCS12.
+
+If the implementation lands first in the Kubernetes TLS secrets feature pack or Elytron, follow-up documentation should be added to the relevant WildFly user documentation.
+
+== Release Note Content
+
+WildFly Elytron now supports native PEM KeyStore loading for Kubernetes-style TLS secrets. This allows PEM certificate and private key files such as `tls.crt` and `tls.key` to be used directly without converting them to JKS or PKCS12 first.


### PR DESCRIPTION
https://redhat.atlassian.net/browse/ELY-3051

This proposal introduces native PEM KeyStore support for Kubernetes TLS secrets in WildFly, allowing direct use of PEM files without conversion to JKS or PKCS12.