### PR TITLE
WFLY-20810 was verified at default

### DIFF
--- a/maven/WFLY-20810_maven_plugin_bootable_jar_cloud.adoc
+++ b/maven/WFLY-20810_maven_plugin_bootable_jar_cloud.adoc
@@ -4,7 +4,7 @@ categories:
   - bootable-jar
   - cloud
   - wf-galleon
-stability-level: community
+stability-level: default
 issue: https://github.com/wildfly/wildfly-proposals/issues/747
 feature-team:
  developer: jfdenise


### PR DESCRIPTION
@jfdenise I see the downstream tracker for this is in Product Docs so to me this one is at default, not community.

I'm going to just merge this because I'm about the reference this analysis in the WF 41 release announcement. If I'm wrong we can revert this.